### PR TITLE
Initialized

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -4,5 +4,6 @@ spring.datasource.password=admin123
 #spring.sql.init.schema-locations=public
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
+#spring.h2.console.enabled=true
 #spring.jpa.properties.hibernate.id.new_generator_mappings=true
 #spring.datasource.hikari.maximum-pool-size=50

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,4 +17,6 @@ spring.datasource.username=tshepo
 spring.datasource.password=tshepo123
 spring.jpa.database=postgresql
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.defer-datasource-initialization=false
+spring.datasource.schema=classpath:schema.sql

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,35 @@
+    drop table if exists book;
+    drop table if exists book_seq;
+    DROP SEQUENCE IF EXISTS book_seq;
+    CREATE SEQUENCE book_seq START WITH 1 INCREMENT BY 50;
+    create table book (
+        id bigint not null DEFAULT nextval('book_seq'),
+        isbn varchar(255),
+        publisher varchar(255),
+        title varchar(255),
+        primary key (id)
+    );
+    create table book_seq (
+        next_val bigint
+    );
+
+    insert into book_seq values (1);
+
+-- DROP TABLE IF EXISTS book;
+-- DROP SEQUENCE IF EXISTS book_seq;
+-- drop table if exists book_seq;
+
+-- CREATE SEQUENCE book_seq START WITH 1 INCREMENT BY 1;
+
+-- CREATE TABLE book (
+--     id BIGINT NOT NULL DEFAULT nextval('book_seq'),
+--     isbn VARCHAR(255),
+--     publisher VARCHAR(255),
+--     title VARCHAR(255),
+--     PRIMARY KEY (id)
+-- );
+-- -- create table book_seq (
+-- --         next_val bigint
+-- -- );
+
+-- insert into book_seq values (50);

--- a/src/test/java/mamabolotgub/springframework/springjpaintro/PostgreSqlIntegrationTest.java
+++ b/src/test/java/mamabolotgub/springframework/springjpaintro/PostgreSqlIntegrationTest.java
@@ -8,17 +8,17 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 import mamabolotgub.springframework.springjpaintro.repositories.BookRepository;
 
 /**
  * Tshepo M Mahudu
  */
-@ActiveProfiles("local")
 @DataJpaTest
 @ComponentScan(basePackages = {"mamabolotgub.springframework.springjpaintro.bootstrap"})
 @AutoConfigureTestDatabase(replace = Replace.NONE)
+@TestPropertySource(locations = "classpath:application.properties")
 public class PostgreSqlIntegrationTest {
     @Autowired
     BookRepository bookRepository;


### PR DESCRIPTION
Okay, in here as I've said in previous issues,  we used the PostgreSql,  you will see there are different things compared to how they did it in MySQL.  One key point is that you must add the @TestPropertySource(locations = "classpath:application.properties") annotation in the PostgreSqlIntegrationTest class to make sure that when tests are running they do not use the application-local file.  This will also need you to recreate the sequence.  Basically you must use the script used when creating the schemas in your db management system.  